### PR TITLE
fix typo 正例

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ function createMenu(config) {
     cancellable: true
   }, config);
 
-  // config now equals: {title: "Foo", body: "Bar", buttonText: "Baz", cancellable: true}
+  // config now equals: {title: "Order", body: "Bar", buttonText: "Send", cancellable: true}
   // ...
 }
 


### PR DESCRIPTION
```javascript
  // config now equals: {title: "Foo", body: "Bar", buttonText: "Baz", cancellable: true}
```

This bit is incorrect and need to be replaced by:
```javascript
// config now equals: {title: "Order", body: "Bar", buttonText: "Send", cancellable: true}
```